### PR TITLE
Fix failing test for header text

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('muestra el encabezado principal', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = screen.getByText(/Recuento de Puntos/i);
+  expect(header).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- fix failing test by expecting "Recuento de Puntos" header

## Testing
- `npm test --silent --no-color` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d814c6f08321abec971a63380b1f